### PR TITLE
Update karotz.class.php

### DIFF
--- a/core/class/karotz.class.php
+++ b/core/class/karotz.class.php
@@ -418,7 +418,7 @@ class karotzCmd extends cmd {
 		if ($this->type != 'action') {
 			return;
 		}
-		$timeout = 10;
+		$timeout = 20;
 		$requestHeader = 'http://' . $karotz->getConfiguration('addr') . '/cgi-bin/';
 		$type = $this->getConfiguration('request');
 		if ($this->getConfiguration('parameters') == '') {


### PR DESCRIPTION
- le timeout de 10 secondes est insuffisant pour la requête humeur où le lapin parle. Il faut environ 20 secondes.
- un meilleur code serait de mettre un timeout de 30 secondes sur la seule requête moods...